### PR TITLE
[1.5.2] - Dependency Declarations, Audit Redaction & Sort Whitelisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,126 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.2] - 2026-08-23
+
+### Security
+
+- `Auditable` no longer writes sensitive attributes into the audit trail. Passwords, tokens, and secrets are excluded by default, and the list is configurable via `lara-util-x.audit.excluded_attributes`. Previously a model using the trait recorded every attribute verbatim, so applying it to `User` stored password hashes and tokens in `model_audits`.
+- `CrudController` now restricts `sort_by` to columns declared in `$sortableFields`. Previously any column could be used to order results, letting a caller infer values from columns they could not otherwise read.
+
+### Added
+
+- `CrudController::$sortableFields` for declaring which columns may be sorted on.
+- `Auditable::auditExcludedAttributes()` for adding per-model exclusions on top of the configured defaults.
+- `audit` configuration block with `table` and `excluded_attributes` keys. The audit table name is no longer hardcoded.
+- Test coverage for `CrudController` and the `Auditable` trait.
+- `CHANGELOG.md`.
+
+### Fixed
+
+- `composer.json` declared no dependencies at all. It now requires `php ^8.1`, the `illuminate/*` components the package actually uses, `nesbot/carbon`, and `guzzlehttp/guzzle`, so Composer can no longer install the package into an incompatible project.
+- Removed `minimum-stability: dev` from `composer.json`, which pushed dev-stability resolution onto anyone installing the package.
+- `CrudController::deleteRecord()` returned a JSON body with a `204 No Content` status, which is not a valid combination. It now returns `200` with the message body.
+- Fixed an order-dependent failure in `MakeCrudCommandTest`. Generated files leaked between tests, so a later test could assert against stale content.
+
+### Changed
+
+- Declared support for Laravel 10, 11, 12, and 13, and PHP 8.1+. The README previously claimed Laravel 8.0+ and PHP 8.0+, neither of which the code supported.
+- Documented the `make:crud` generator and the `XHelper` class in the README, and removed the entry for `ValidationHelperTrait`, which does not exist in the package.
+
+## [1.5.1] - 2026-03-17
+
+### Fixed
+
+- Synced the version declared in `composer.json`.
+
+## [1.5.0] - 2026-03-16
+
+### Added
+
+- `make:crud` API CRUD generator, producing a model, controller, and migration from a field definition, with support for relationships, soft deletes, searchable fields, and route registration.
+
+## [1.4.0] - 2025-12-29
+
+### Added
+
+- `XHelper` class collecting array, string, date, and UUID helpers.
+
+## [1.3.1] - 2025-12-23
+
+### Fixed
+
+- Resolved test suite issues and removed the `CachingUtil` feature test.
+
+## [1.3.0] - 2025-10-23
+
+### Added
+
+- Test suite covering the utilities, traits, enums, and validation rules.
+
+## [1.2.0] - 2025-10-13
+
+### Added
+
+- `RejectCommonPasswords` validation rule.
+
+## [1.1.8] - 2025-10-10
+
+### Fixed
+
+- `CachingUtil` behavior.
+
+## [1.1.7] - 2025-09-27
+
+### Added
+
+- Claude LLM provider.
+
+## [1.1.6] - 2025-09-12
+
+### Added
+
+- Gemini LLM provider.
+
+## [1.1.5] - 2025-08-19
+
+### Fixed
+
+- `RateLimiterUtil` behavior.
+
+## [1.1.4] - 2025-07-24
+
+### Added
+
+- Enums, and a new method on `PaginationUtil`.
+
+## [1.1.3] - 2025-07-12
+
+### Changed
+
+- Enhanced `ApiResponseTrait`.
+
+## [1.1.2] - 2025-06-30
+
+### Removed
+
+- Committed vendor directory.
+
+[1.5.2]: https://github.com/omarchouman/lara-util-x/compare/1.5.1...1.5.2
+[1.5.1]: https://github.com/omarchouman/lara-util-x/compare/1.5.0...1.5.1
+[1.5.0]: https://github.com/omarchouman/lara-util-x/compare/1.4.0...1.5.0
+[1.4.0]: https://github.com/omarchouman/lara-util-x/compare/1.3.1...1.4.0
+[1.3.1]: https://github.com/omarchouman/lara-util-x/compare/1.3.0...1.3.1
+[1.3.0]: https://github.com/omarchouman/lara-util-x/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/omarchouman/lara-util-x/compare/1.1.8...1.2.0
+[1.1.8]: https://github.com/omarchouman/lara-util-x/compare/1.1.7...1.1.8
+[1.1.7]: https://github.com/omarchouman/lara-util-x/compare/1.1.6...1.1.7
+[1.1.6]: https://github.com/omarchouman/lara-util-x/compare/1.1.5...1.1.6
+[1.1.5]: https://github.com/omarchouman/lara-util-x/compare/1.1.4...1.1.5
+[1.1.4]: https://github.com/omarchouman/lara-util-x/compare/1.1.3...1.1.4
+[1.1.3]: https://github.com/omarchouman/lara-util-x/compare/1.1.2...1.1.3
+[1.1.2]: https://github.com/omarchouman/lara-util-x/releases/tag/1.1.2

--- a/Readme.md
+++ b/Readme.md
@@ -6,9 +6,9 @@
 
 LaraUtilX is a comprehensive Laravel package designed to supercharge your development experience by providing a suite of utility classes, helpful traits, middleware, and more. Whether you're a seasoned Laravel developer or just getting started, LaraUtilX offers a collection of tools to streamline common tasks and enhance the functionality of your Laravel applications.
 
-**Version:** 1.3.0  
-**Laravel Support:** Laravel 8.0+  
-**PHP Support:** PHP 8.0+  
+**Version:** 1.5.2  
+**Laravel Support:** Laravel 10, 11, 12, 13  
+**PHP Support:** PHP 8.1+  
 **License:** MIT
 
 ---
@@ -27,7 +27,7 @@ Explore full usage examples, configuration options, and best practices at:
 
 3. **FileProcessingTrait:** Manage file uploads and deletions seamlessly with the `FileProcessingTrait`. This trait offers methods for uploading single or multiple files, deleting files, and now retrieving file contents.
 
-4. **ValidationHelperTrait:** Validate user input with ease using the `ValidationHelperTrait`. This trait includes handy methods for common validation scenarios, such as email addresses, phone numbers, and strong passwords.
+4. **CRUD Generator:** Scaffold a complete API resource in one command with `php artisan make:crud`. Generates the model, controller, and migration from a field definition, with support for relationships, soft deletes, searchable fields, and automatic route registration.
 
 5. **SchedulerMonitor:** Keep an eye on your scheduled tasks with the `SchedulerUtil` utility. Monitor upcoming scheduled events, check if tasks are overdue, and gain insights into the status of your scheduled jobs.
 
@@ -56,9 +56,60 @@ Explore full usage examples, configuration options, and best practices at:
 
 15. **RateLimiterUtil:** Implement rate limiting for your APIs and endpoints using the `RateLimiterUtil`. Control request frequency, prevent abuse, and manage API usage with configurable limits and decay times.
 
-16. **Auditable Trait:** Automatically track model changes with the `Auditable` trait. Log create, update, and delete operations with user context, old values, and new values. Perfect for audit trails and compliance requirements.
+16. **Auditable Trait:** Automatically track model changes with the `Auditable` trait. Log create, update, and delete operations with user context, old values, and new values. Sensitive attributes such as passwords and tokens are excluded from the trail by default, and both the exclusion list and the audit table name are configurable.
 
 17. **RejectCommonPasswords Rule:** Strengthen password security with the `RejectCommonPasswords` validation rule. Prevent users from using common, easily guessable passwords with a comprehensive list of weak passwords.
+
+18. **XHelper:** Reach for a grab-bag of small helpers via the `XHelper` class — array trimming and flattening, substring extraction, slugification, Carbon date parsing and human-readable diffs, and UUID generation.
+
+## CRUD Generator
+
+Scaffold a model, an API controller, and a migration in a single command:
+
+```bash
+php artisan make:crud Post --fields="title:string:required,body:text:nullable,price:decimal:required|min:0"
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--fields=` | Comma-separated `column:type:validation` definitions |
+| `--belongs-to=` | Add a BelongsTo relationship (repeatable) |
+| `--has-many=` | Add a HasMany relationship (repeatable) |
+| `--has-one=` | Add a HasOne relationship (repeatable) |
+| `--belongs-to-many=` | Add a BelongsToMany relationship (repeatable) |
+| `--soft-deletes` | Enable soft delete support |
+| `--searchable=` | Comma-separated fields to enable search on |
+| `--per-page=` | Default items per page (defaults to 15) |
+| `--register-routes` | Append the `apiResource` route to `routes/api.php` |
+| `--migrate` | Run `php artisan migrate` after generating |
+| `--force` | Overwrite existing files |
+
+Existing files are never overwritten unless you pass `--force`; the command warns and skips instead.
+
+```bash
+php artisan make:crud Post \
+    --fields="title:string:required,body:text:nullable" \
+    --belongs-to=User \
+    --has-many=Comment \
+    --searchable=title,body \
+    --soft-deletes \
+    --register-routes
+```
+
+## Sorting in CrudController
+
+`CrudController` accepts `sort_by` and `sort_direction` query parameters, but only for columns you explicitly allow. This keeps a caller from ordering by columns they should never be able to observe, such as password hashes or tokens:
+
+```php
+class PostController extends CrudController
+{
+    protected array $sortableFields = ['title', 'created_at'];
+}
+```
+
+A `sort_by` value outside `$sortableFields` is ignored rather than rejected. When the list is empty, no sorting is applied at all.
 
 ## Test Suite
 
@@ -71,7 +122,7 @@ LaraUtilX comes with a comprehensive test suite that ensures reliability and qua
 Make sure you have installed the development dependencies:
 
 ```bash
-composer install --dev
+composer install
 ```
 
 #### Run All Tests
@@ -122,12 +173,15 @@ The test suite provides comprehensive coverage for:
 tests/
 ├── TestCase.php                    # Base test case with Laravel setup
 ├── Unit/                          # Unit tests for individual components
+│   ├── Console/
+│   │   └── MakeCrudCommandTest.php
 │   ├── Enums/
 │   │   └── LogLevelTest.php
 │   ├── Rules/
 │   │   └── RejectCommonPasswordsTest.php
 │   ├── Traits/
 │   │   ├── ApiResponseTraitTest.php
+│   │   ├── AuditableTest.php
 │   │   └── FileProcessingTraitTest.php
 │   └── Utilities/
 │       ├── CachingUtilTest.php
@@ -140,10 +194,11 @@ tests/
 │       ├── RateLimiterUtilTest.php
 │       └── SchedulerUtilTest.php
 └── Feature/                       # Integration tests
-    ├── Traits/
-    │   └── ApiResponseTraitFeatureTest.php
-    └── Utilities/
-        └── CachingUtilFeatureTest.php
+    ├── Http/
+    │   └── Controllers/
+    │       └── CrudControllerTest.php
+    └── Traits/
+        └── ApiResponseTraitFeatureTest.php
 ```
 
 ## How to Get Started
@@ -162,7 +217,7 @@ LaraUtilX is actively maintained and welcomes contributions! The package include
 ### Development Setup
 
 1. Clone the repository
-2. Install dependencies: `composer install --dev`
+2. Install dependencies: `composer install`
 3. Run tests: `./vendor/bin/phpunit`
 4. Check code coverage: `./vendor/bin/phpunit --coverage-html coverage`
 

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,24 @@
             "email": "omar.chouman0@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
-    "require": {},
+    "require": {
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.0",
+        "illuminate/cache": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+        "nesbot/carbon": "^2.67|^3.0"
+    },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
-        "orchestra/testbench": "^8.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6.12"
     },
     "autoload": {

--- a/config/lara-util-x.php
+++ b/config/lara-util-x.php
@@ -10,6 +10,22 @@ return [
         'default_tags' => [],
     ],
 
+    'audit' => [
+        'table' => 'model_audits',
+
+        // Never written to the audit trail by the Auditable trait.
+        'excluded_attributes' => [
+            'password',
+            'password_confirmation',
+            'remember_token',
+            'api_token',
+            'access_token',
+            'refresh_token',
+            'secret',
+            'token',
+        ],
+    ],
+
     'rate_limiting' => [
         'default_max_attempts' => 60,
         'default_decay_minutes' => 1,

--- a/src/Http/Controllers/CrudController.php
+++ b/src/Http/Controllers/CrudController.php
@@ -14,6 +14,7 @@ abstract class CrudController extends Controller
     protected Model $model;
     protected array $validationRules = [];
     protected array $searchableFields = [];
+    protected array $sortableFields = [];
     protected array $relationships = [];
     protected int $perPage = 15;
 
@@ -40,10 +41,7 @@ abstract class CrudController extends Controller
             $query->with($this->relationships);
         }
 
-        if ($request->has('sort_by')) {
-            $direction = $request->get('sort_direction', 'asc');
-            $query->orderBy($request->get('sort_by'), $direction);
-        }
+        $this->applySorting($query, $request);
 
         $records = $query->paginate($request->get('per_page', $this->perPage));
 
@@ -116,7 +114,25 @@ abstract class CrudController extends Controller
 
         return response()->json([
             'message' => 'Record deleted successfully'
-        ], 204);
+        ]);
+    }
+
+
+    /**
+     * Sorting is restricted to $sortableFields so a request cannot order by
+     * columns it should never see, such as password hashes or tokens.
+     */
+    protected function applySorting($query, Request $request): void
+    {
+        $column = $request->input('sort_by');
+
+        if (! $column || ! in_array($column, $this->sortableFields, true)) {
+            return;
+        }
+
+        $direction = strtolower($request->input('sort_direction', 'asc'));
+
+        $query->orderBy($column, $direction === 'desc' ? 'desc' : 'asc');
     }
 
 

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -23,17 +23,31 @@ trait Auditable
         });
     }
 
+    /**
+     * Attributes that never reach the audit trail. Override on the model to add
+     * your own on top of the configured defaults.
+     */
+    protected static function auditExcludedAttributes(): array
+    {
+        return config('lara-util-x.audit.excluded_attributes', []);
+    }
+
     private static function logAudit(Model $model, string $event, array $oldValues = [], array $newValues = []): void
     {
-        DB::table('model_audits')->insert([
+        DB::table(config('lara-util-x.audit.table', 'model_audits'))->insert([
             'model_type' => get_class($model),
             'model_id' => $model->getKey(),
             'event' => $event,
-            'old_values' => json_encode($oldValues),
-            'new_values' => json_encode($newValues),
+            'old_values' => json_encode(self::withoutExcludedAttributes($oldValues)),
+            'new_values' => json_encode(self::withoutExcludedAttributes($newValues)),
             'user_id' => Auth::id(),
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+    }
+
+    private static function withoutExcludedAttributes(array $values): array
+    {
+        return array_diff_key($values, array_flip(static::auditExcludedAttributes()));
     }
 }

--- a/tests/Feature/Http/Controllers/CrudControllerTest.php
+++ b/tests/Feature/Http/Controllers/CrudControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace LaraUtilX\Tests\Feature\Http\Controllers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use LaraUtilX\Http\Controllers\CrudController;
+use LaraUtilX\Tests\TestCase;
+
+class CrudControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('crud_products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('secret_code');
+            $table->timestamps();
+        });
+
+        // Insertion order is deliberately not alphabetical, so a sorted result
+        // is distinguishable from an unsorted one.
+        CrudProduct::insert([
+            ['id' => 1, 'name' => 'Banana', 'secret_code' => 'ccc'],
+            ['id' => 2, 'name' => 'Apple', 'secret_code' => 'bbb'],
+            ['id' => 3, 'name' => 'Cherry', 'secret_code' => 'aaa'],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('crud_products');
+
+        parent::tearDown();
+    }
+
+    private function names(Request $request, ?CrudController $controller = null): array
+    {
+        $controller = $controller ?: new ProductCrudController(new CrudProduct());
+
+        $response = $controller->getAllRecords($request);
+
+        return array_column($response->getData(true)['data'], 'name');
+    }
+
+    // -----------------------------------------------------------------------
+    // Sorting
+    // -----------------------------------------------------------------------
+
+    public function test_sorts_by_whitelisted_column()
+    {
+        $names = $this->names(Request::create('/products?sort_by=name'));
+
+        $this->assertEquals(['Apple', 'Banana', 'Cherry'], $names);
+    }
+
+    public function test_sorts_descending_when_requested()
+    {
+        $names = $this->names(Request::create('/products?sort_by=name&sort_direction=desc'));
+
+        $this->assertEquals(['Cherry', 'Banana', 'Apple'], $names);
+    }
+
+    public function test_ignores_sort_on_non_whitelisted_column()
+    {
+        $names = $this->names(Request::create('/products?sort_by=secret_code'));
+
+        // secret_code ordering would be Cherry, Apple, Banana.
+        $this->assertEquals(['Banana', 'Apple', 'Cherry'], $names);
+    }
+
+    public function test_ignores_sort_when_no_sortable_fields_are_declared()
+    {
+        $names = $this->names(
+            Request::create('/products?sort_by=name'),
+            new UnsortableProductCrudController(new CrudProduct())
+        );
+
+        $this->assertEquals(['Banana', 'Apple', 'Cherry'], $names);
+    }
+
+    public function test_invalid_sort_direction_falls_back_to_ascending()
+    {
+        $names = $this->names(Request::create('/products?sort_by=name&sort_direction=; DROP TABLE'));
+
+        $this->assertEquals(['Apple', 'Banana', 'Cherry'], $names);
+    }
+
+    // -----------------------------------------------------------------------
+    // Delete
+    // -----------------------------------------------------------------------
+
+    public function test_delete_returns_200_with_a_readable_body()
+    {
+        $controller = new ProductCrudController(new CrudProduct());
+
+        $response = $controller->deleteRecord(1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Record deleted successfully', $response->getData(true)['message']);
+        $this->assertNull(CrudProduct::find(1));
+    }
+}
+
+class CrudProduct extends Model
+{
+    protected $table = 'crud_products';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+class ProductCrudController extends CrudController
+{
+    protected array $sortableFields = ['name'];
+}
+
+class UnsortableProductCrudController extends CrudController
+{
+}

--- a/tests/Unit/Console/MakeCrudCommandTest.php
+++ b/tests/Unit/Console/MakeCrudCommandTest.php
@@ -9,8 +9,18 @@ class MakeCrudCommandTest extends TestCase
     private array $cleanup = [];
 
     // -----------------------------------------------------------------------
-    // Teardown
+    // Setup & Teardown
     // -----------------------------------------------------------------------
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Every test in this file generates the same Product files. A leftover
+        // file makes the generator warn and skip, so the next test would assert
+        // against stale content.
+        $this->removeGeneratedFiles();
+    }
 
     protected function tearDown(): void
     {
@@ -20,7 +30,23 @@ class MakeCrudCommandTest extends TestCase
             }
         }
 
+        $this->removeGeneratedFiles();
+
         parent::tearDown();
+    }
+
+    private function removeGeneratedFiles(): void
+    {
+        $paths = array_merge([
+            app_path('Models/Product.php'),
+            app_path('Http/Controllers/ProductController.php'),
+        ], glob(database_path('migrations/*_create_products_table.php')) ?: []);
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
     }
 
     private function track(string $path): string

--- a/tests/Unit/Traits/AuditableTest.php
+++ b/tests/Unit/Traits/AuditableTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace LaraUtilX\Tests\Unit\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use LaraUtilX\Tests\TestCase;
+use LaraUtilX\Traits\Auditable;
+
+class AuditableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate')->run();
+
+        Schema::create('audit_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('password')->nullable();
+            $table->string('remember_token')->nullable();
+            $table->string('nickname')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('audit_accounts');
+
+        parent::tearDown();
+    }
+
+    private function latestAudit(): object
+    {
+        return DB::table('model_audits')->orderByDesc('id')->first();
+    }
+
+    // -----------------------------------------------------------------------
+    // Excluded attributes
+    // -----------------------------------------------------------------------
+
+    public function test_create_audit_excludes_sensitive_attributes()
+    {
+        AuditAccount::create([
+            'name' => 'Ada',
+            'password' => 'hashed-secret',
+            'remember_token' => 'token-value',
+        ]);
+
+        $newValues = json_decode($this->latestAudit()->new_values, true);
+
+        $this->assertArrayNotHasKey('password', $newValues);
+        $this->assertArrayNotHasKey('remember_token', $newValues);
+        $this->assertEquals('Ada', $newValues['name']);
+    }
+
+    public function test_update_audit_excludes_sensitive_attributes_from_both_sides()
+    {
+        $account = AuditAccount::create([
+            'name' => 'Ada',
+            'password' => 'old-secret',
+        ]);
+
+        $account->update(['name' => 'Grace', 'password' => 'new-secret']);
+
+        $audit = $this->latestAudit();
+        $oldValues = json_decode($audit->old_values, true);
+        $newValues = json_decode($audit->new_values, true);
+
+        $this->assertEquals('updated', $audit->event);
+        $this->assertArrayNotHasKey('password', $oldValues);
+        $this->assertArrayNotHasKey('password', $newValues);
+        $this->assertEquals('Grace', $newValues['name']);
+    }
+
+    public function test_delete_audit_excludes_sensitive_attributes()
+    {
+        $account = AuditAccount::create([
+            'name' => 'Ada',
+            'password' => 'hashed-secret',
+        ]);
+
+        $account->delete();
+
+        $audit = $this->latestAudit();
+
+        $this->assertEquals('deleted', $audit->event);
+        $this->assertArrayNotHasKey('password', json_decode($audit->old_values, true));
+    }
+
+    public function test_non_sensitive_attributes_are_still_recorded()
+    {
+        AuditAccount::create(['name' => 'Ada', 'nickname' => 'countess']);
+
+        $newValues = json_decode($this->latestAudit()->new_values, true);
+
+        $this->assertEquals('countess', $newValues['nickname']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Configuration
+    // -----------------------------------------------------------------------
+
+    public function test_model_can_exclude_additional_attributes()
+    {
+        SecretiveAuditAccount::create(['name' => 'Ada', 'nickname' => 'countess']);
+
+        $newValues = json_decode($this->latestAudit()->new_values, true);
+
+        $this->assertArrayNotHasKey('nickname', $newValues);
+        $this->assertEquals('Ada', $newValues['name']);
+    }
+
+    public function test_excluded_attributes_are_configurable()
+    {
+        Config::set('lara-util-x.audit.excluded_attributes', ['name']);
+
+        AuditAccount::create(['name' => 'Ada', 'nickname' => 'countess']);
+
+        $newValues = json_decode($this->latestAudit()->new_values, true);
+
+        $this->assertArrayNotHasKey('name', $newValues);
+        $this->assertEquals('countess', $newValues['nickname']);
+    }
+
+    public function test_audit_table_name_is_configurable()
+    {
+        Schema::create('custom_audits', function (Blueprint $table) {
+            $table->id();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id')->nullable();
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->timestamps();
+        });
+
+        Config::set('lara-util-x.audit.table', 'custom_audits');
+
+        AuditAccount::create(['name' => 'Ada']);
+
+        $this->assertEquals(1, DB::table('custom_audits')->count());
+        $this->assertEquals(0, DB::table('model_audits')->count());
+
+        Schema::dropIfExists('custom_audits');
+    }
+}
+
+class AuditAccount extends Model
+{
+    use Auditable;
+
+    protected $table = 'audit_accounts';
+    protected $guarded = [];
+}
+
+class SecretiveAuditAccount extends AuditAccount
+{
+    protected static function auditExcludedAttributes(): array
+    {
+        return array_merge(parent::auditExcludedAttributes(), ['nickname']);
+    }
+}


### PR DESCRIPTION
## Summary

Patch release focused on making the package safe to install and closing two data-exposure defects.

### Security

- **`Auditable` no longer writes sensitive attributes to the audit trail.** Previously every attribute was recorded verbatim, so applying the trait to `User` stored password hashes and tokens in `model_audits`. Passwords, tokens and secrets are now excluded by default via `lara-util-x.audit.excluded_attributes`, and models can add their own through `auditExcludedAttributes()`.
- **`CrudController` restricts `sort_by` to `$sortableFields`.** Any column could previously be used to order results, letting a caller infer values from columns they could not otherwise read.

### Fixed

- `composer.json` declared **no dependencies at all** — not even a `php` constraint. It now requires `php ^8.1`, the `illuminate/*` components the package actually imports, `nesbot/carbon` and `guzzlehttp/guzzle`.
- Removed `minimum-stability: dev`, which pushed dev-stability resolution onto consumers.
- `deleteRecord()` returned a JSON body with a `204 No Content` status, which is not a valid combination. Now returns `200`.
- `MakeCrudCommandTest` leaked generated files between tests, causing an order-dependent failure (~25% of random-order runs).

### Added

- `audit` config block with configurable table name and exclusion list.
- Test coverage for `CrudController` and the `Auditable` trait — 162 → 175 tests.
- `CHANGELOG.md`, backfilled from existing tags.

### Changed

- Support declared for Laravel 10–13 and PHP 8.1+. The README previously claimed Laravel 8.0+ / PHP 8.0+, neither of which the code supported — `Illuminate\Contracts\Validation\ValidationRule` is Laravel 10+, and `readonly` properties plus backed enums require PHP 8.1.
- README documents `make:crud` and `XHelper`, and drops `ValidationHelperTrait`, which does not exist in the package.

## Verification

Full suite run against every declared version:

| Laravel | PHPUnit | Result |
|---|---|---|
| 10.50.3 | 10.5.64 | 175 passed |
| 11.56.0 | 12.5.33 | 175 passed |
| 12.67.0 | 12.5.33 | 175 passed |
| 13.26.1 | 12.5.33 | 175 passed |

Plus 0 failures across 10 random-order runs, and each new test was confirmed to fail against the pre-fix code (9 failures + 1 error of 13).

> **Merge with a merge commit, not squash.** The `1.5.2` tag already points at `7f003e4`; squashing would orphan it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186FKrzgVUDk36BSYhq9j4Y