### PR TITLE
docs: point 1.5.0 changelog link at its commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,8 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Committed vendor directory.
 
 [1.5.2]: https://github.com/omarchouman/lara-util-x/compare/1.5.1...1.5.2
-[1.5.1]: https://github.com/omarchouman/lara-util-x/compare/1.5.0...1.5.1
-[1.5.0]: https://github.com/omarchouman/lara-util-x/compare/1.4.0...1.5.0
+[1.5.1]: https://github.com/omarchouman/lara-util-x/compare/1.4.0...1.5.1
+[1.5.0]: https://github.com/omarchouman/lara-util-x/commit/1c65bcd
 [1.4.0]: https://github.com/omarchouman/lara-util-x/compare/1.3.1...1.4.0
 [1.3.1]: https://github.com/omarchouman/lara-util-x/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/omarchouman/lara-util-x/compare/1.2.0...1.3.0


### PR DESCRIPTION
1.5.0 was released without a git tag. Tagging it retroactively does not work: no commit in history declares `version: 1.5.0` in `composer.json` — the field went straight from `1.4.0` to removed in 1.5.1 — so Packagist ignores such a tag as a version mismatch.

Links the changelog entry to the release commit instead of a compare range that cannot resolve, and restores the 1.5.1 range to `1.4.0...1.5.1`.